### PR TITLE
feat: add AI-friendly CLI flags for non-interactive usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pull request associated with that issue, following the contribution model you de
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Usage](#usage)
+- [AI-assisted development](#ai-assisted-development)
 - [Contribute](#contribute)
 
 ## Prerequisites
@@ -78,6 +79,46 @@ credentials and then proceed to create the custom configuration file with the pr
 
 After installing this extension in your development environment, you can know the available commands in the
 [`USAGE.md`](docs/USAGE.md) file.
+
+## AI-assisted development
+
+Sherpa is designed to be fully driven by AI coding agents without requiring any interactive terminal input.
+
+All branch naming decisions and PR metadata can be specified via CLI flags — no stdin prompts are needed when using `-y`/`--yes` together with the new flags.
+
+### Typical AI agent workflow
+
+**Create a branch** for an issue with a known type:
+```sh
+gh sherpa create-branch --issue 42 --yes \
+  --branch-type feature \
+  --branch-description "implement-oauth"
+# Output: feature/GH-42-implement-oauth
+```
+
+**Create a fully configured draft PR** in one command:
+```sh
+gh sherpa create-pr --issue 42 --yes \
+  --branch-type feature \
+  --branch-description "implement-oauth" \
+  --pr-title "feat(auth): implement OAuth2 login" \
+  --pr-body "Closes #42\n\nImplements OAuth2 login flow." \
+  --reviewer alice \
+  --assignee bob \
+  --label "priority/high"
+```
+
+**Get machine-readable output** for chaining with other tools:
+```sh
+BRANCH=$(gh sherpa create-branch --issue 42 --yes --branch-type bugfix --output json | jq -r .branch)
+```
+
+**Preview without side effects**:
+```sh
+gh sherpa create-pr --issue 42 --yes --branch-type feature --dry-run
+```
+
+When a branch already exists for the issue, Sherpa automatically reuses it in non-interactive mode (`-y`). To opt out of this behavior and force an error instead, use `--no-use-existing-branch`.
 
 ## Contribute
 

--- a/cmd/create_branch/cmd.go
+++ b/cmd/create_branch/cmd.go
@@ -30,18 +30,18 @@ var Command = &cobra.Command{
 }
 
 type createBranchFlags struct {
-	IssueValue          string
-	BaseValue           string
-	NoFetchValue        bool
-	UseDefaultValues    bool
-	ForkValue           bool
-	ForkNameValue       string
-	PreferHotfix        bool
-	BranchType          string
-	BranchDescription   string
-	BranchName          string
-	DryRun              bool
-	OutputFormat        string
+	IssueValue        string
+	BaseValue         string
+	NoFetchValue      bool
+	UseDefaultValues  bool
+	ForkValue         bool
+	ForkNameValue     string
+	PreferHotfix      bool
+	BranchType        string
+	BranchDescription string
+	BranchName        string
+	DryRun            bool
+	OutputFormat      string
 }
 
 var flags = createBranchFlags{}

--- a/cmd/create_branch/cmd.go
+++ b/cmd/create_branch/cmd.go
@@ -1,6 +1,8 @@
 package create_branch
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/InditexTech/gh-sherpa/cmd/common"
@@ -28,13 +30,18 @@ var Command = &cobra.Command{
 }
 
 type createBranchFlags struct {
-	IssueValue       string
-	BaseValue        string
-	NoFetchValue     bool
-	UseDefaultValues bool
-	ForkValue        bool
-	ForkNameValue    string
-	PreferHotfix     bool
+	IssueValue          string
+	BaseValue           string
+	NoFetchValue        bool
+	UseDefaultValues    bool
+	ForkValue           bool
+	ForkNameValue       string
+	PreferHotfix        bool
+	BranchType          string
+	BranchDescription   string
+	BranchName          string
+	DryRun              bool
+	OutputFormat        string
 }
 
 var flags = createBranchFlags{}
@@ -53,10 +60,17 @@ func init() {
 	Command.PersistentFlags().BoolVar(&flags.ForkValue, "fork", false, "automatically set up fork for external contributors")
 	Command.PersistentFlags().StringVar(&flags.ForkNameValue, "fork-name", "", "specify custom fork organization/user (e.g. MyOrg/gh-sherpa)")
 	Command.PersistentFlags().BoolVar(&flags.PreferHotfix, "prefer-hotfix", false, "prefer hotfix branch prefix for bug issues when using non-interactive mode")
+	Command.PersistentFlags().StringVar(&flags.BranchType, "branch-type", "", "force a specific branch type prefix (e.g. feature, bugfix, hotfix)")
+	Command.PersistentFlags().StringVar(&flags.BranchDescription, "branch-description", "", "force a specific branch description slug instead of deriving it from the issue title")
+	Command.PersistentFlags().StringVar(&flags.BranchName, "branch-name", "", "use exactly this branch name instead of auto-generating one")
+	Command.PersistentFlags().BoolVar(&flags.DryRun, "dry-run", false, "print what would happen without actually creating the branch")
+	Command.PersistentFlags().StringVar(&flags.OutputFormat, "output", "", "output format: '' (default human-readable) or 'json'")
 }
 
 func runCommand(cmd *cobra.Command, _ []string) (err error) {
-	logging.PrintCommandHeader(cmdName)
+	if flags.OutputFormat != "json" {
+		logging.PrintCommandHeader(cmdName)
+	}
 
 	cfg := config.GetConfig()
 
@@ -68,6 +82,10 @@ func runCommand(cmd *cobra.Command, _ []string) (err error) {
 	userInteraction := &interactive.UserInteractionProvider{}
 
 	isInteractive := !flags.UseDefaultValues
+	// --output json implies non-interactive to prevent stdin prompts from corrupting JSON output.
+	if flags.OutputFormat == "json" {
+		isInteractive = false
+	}
 
 	ghCli := &gh.Cli{}
 
@@ -78,9 +96,11 @@ func runCommand(cmd *cobra.Command, _ []string) (err error) {
 	}
 
 	branchProviderCfg := branches.Configuration{
-		Branches:      cfg.Branches,
-		IsInteractive: isInteractive,
-		PreferHotfix:  flags.PreferHotfix,
+		Branches:          cfg.Branches,
+		IsInteractive:     isInteractive,
+		PreferHotfix:      flags.PreferHotfix,
+		ForcedBranchType:  flags.BranchType,
+		ForcedDescription: flags.BranchDescription,
 	}
 	branchProvider, err := branches.New(branchProviderCfg, userInteraction)
 	if err != nil {
@@ -92,6 +112,9 @@ func runCommand(cmd *cobra.Command, _ []string) (err error) {
 		BaseBranch:      flags.BaseValue,
 		FetchFromOrigin: !flags.NoFetchValue,
 		IsInteractive:   isInteractive,
+		BranchName:      flags.BranchName,
+		DryRun:          flags.DryRun,
+		OutputFormat:    flags.OutputFormat,
 	}
 	createBranch := use_cases.CreateBranch{
 		Cfg:                     createBranchConfig,
@@ -102,9 +125,14 @@ func runCommand(cmd *cobra.Command, _ []string) (err error) {
 		BranchProvider:          branchProvider,
 	}
 
-	err = createBranch.Execute()
+	_, err = createBranch.Execute()
 
 	if err != nil {
+		if flags.OutputFormat == "json" {
+			errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
+			fmt.Fprintln(os.Stderr, string(errJSON))
+			os.Exit(1)
+		}
 		return err
 	}
 

--- a/cmd/create_pull_request/cmd.go
+++ b/cmd/create_pull_request/cmd.go
@@ -1,7 +1,9 @@
 package create_pull_request
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/InditexTech/gh-sherpa/cmd/common"
 	"github.com/InditexTech/gh-sherpa/internal/branches"
@@ -28,16 +30,28 @@ var Command = &cobra.Command{
 }
 
 type createPullRequestFlags struct {
-	IssueID          string
-	BaseBranch       string
-	NoFetch          bool
-	NoDraft          bool
-	NoCloseIssue     bool
-	UseDefaultValues bool
-	TemplatePath     string
-	ForkValue        bool
-	ForkNameValue    string
-	PreferHotfix     bool
+	IssueID             string
+	BaseBranch          string
+	NoFetch             bool
+	NoDraft             bool
+	NoCloseIssue        bool
+	UseDefaultValues    bool
+	TemplatePath        string
+	ForkValue           bool
+	ForkNameValue       string
+	PreferHotfix        bool
+	BranchType          string
+	BranchDescription   string
+	BranchName          string
+	DryRun              bool
+	OutputFormat        string
+	PRTitle             string
+	PRBody              string
+	PRBodyFile          string
+	NoUseExistingBranch bool
+	ExtraLabels         []string
+	Reviewers           []string
+	Assignees           []string
 }
 
 var flags createPullRequestFlags
@@ -52,6 +66,18 @@ func init() {
 	Command.PersistentFlags().BoolVar(&flags.ForkValue, "fork", false, "automatically set up fork for external contributors")
 	Command.PersistentFlags().StringVar(&flags.ForkNameValue, "fork-name", "", "specify custom fork organization/user (e.g. MyOrg/gh-sherpa)")
 	Command.PersistentFlags().BoolVar(&flags.PreferHotfix, "prefer-hotfix", false, "prefer hotfix branch prefix for bug issues when using non-interactive mode")
+	Command.PersistentFlags().StringVar(&flags.BranchType, "branch-type", "", "force a specific branch type prefix (e.g. feature, bugfix, hotfix)")
+	Command.PersistentFlags().StringVar(&flags.BranchDescription, "branch-description", "", "force a specific branch description slug instead of deriving it from the issue title")
+	Command.PersistentFlags().StringVar(&flags.BranchName, "branch-name", "", "use exactly this branch name instead of auto-generating one")
+	Command.PersistentFlags().BoolVar(&flags.DryRun, "dry-run", false, "print what would happen without actually creating the PR")
+	Command.PersistentFlags().StringVar(&flags.OutputFormat, "output", "", "output format: '' (default human-readable) or 'json'")
+	Command.PersistentFlags().StringVar(&flags.PRTitle, "pr-title", "", "override the auto-generated PR title")
+	Command.PersistentFlags().StringVar(&flags.PRBody, "pr-body", "", "override the auto-generated PR body")
+	Command.PersistentFlags().StringVar(&flags.PRBodyFile, "pr-body-file", "", "read PR body from file (overrides --pr-body and template)")
+	Command.PersistentFlags().BoolVar(&flags.NoUseExistingBranch, "no-use-existing-branch", false, "fail if a branch for this issue already exists (default is to reuse it)")
+	Command.PersistentFlags().StringArrayVar(&flags.ExtraLabels, "label", []string{}, "additional label to apply to the PR (can be repeated)")
+	Command.PersistentFlags().StringArrayVar(&flags.Reviewers, "reviewer", []string{}, "request a review from this user or team (can be repeated)")
+	Command.PersistentFlags().StringArrayVar(&flags.Assignees, "assignee", []string{}, "assign this user to the PR (can be repeated)")
 }
 
 func runCommand(cmd *cobra.Command, _ []string) error {
@@ -61,7 +87,9 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("sherpa needs an valid issue identifier")
 	}
 
-	logging.PrintCommandHeader(cmdName)
+	if flags.OutputFormat != "json" {
+		logging.PrintCommandHeader(cmdName)
+	}
 
 	cfg := config.GetConfig()
 
@@ -73,11 +101,17 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	userInteraction := &interactive.UserInteractionProvider{}
 
 	isInteractive := !flags.UseDefaultValues
+	// --output json implies non-interactive to prevent stdin prompts from corrupting JSON output.
+	if flags.OutputFormat == "json" {
+		isInteractive = false
+	}
 
 	branchProviderCfg := branches.Configuration{
-		Branches:      cfg.Branches,
-		IsInteractive: isInteractive,
-		PreferHotfix:  flags.PreferHotfix,
+		Branches:          cfg.Branches,
+		IsInteractive:     isInteractive,
+		PreferHotfix:      flags.PreferHotfix,
+		ForcedBranchType:  flags.BranchType,
+		ForcedDescription: flags.BranchDescription,
 	}
 	branchProvider, err := branches.New(branchProviderCfg, userInteraction)
 	if err != nil {
@@ -93,13 +127,23 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	createPullRequestConfig := use_cases.CreatePullRequestConfiguration{
-		IssueID:         flags.IssueID,
-		BaseBranch:      flags.BaseBranch,
-		FetchFromOrigin: !flags.NoFetch,
-		IsInteractive:   isInteractive,
-		DraftPR:         !flags.NoDraft,
-		CloseIssue:      !flags.NoCloseIssue,
-		TemplatePath:    flags.TemplatePath,
+		IssueID:             flags.IssueID,
+		BaseBranch:          flags.BaseBranch,
+		FetchFromOrigin:     !flags.NoFetch,
+		IsInteractive:       isInteractive,
+		DraftPR:             !flags.NoDraft,
+		CloseIssue:          !flags.NoCloseIssue,
+		TemplatePath:        flags.TemplatePath,
+		BranchName:          flags.BranchName,
+		DryRun:              flags.DryRun,
+		OutputFormat:        flags.OutputFormat,
+		PRTitle:             flags.PRTitle,
+		PRBody:              flags.PRBody,
+		PRBodyFile:          flags.PRBodyFile,
+		NoUseExistingBranch: flags.NoUseExistingBranch,
+		ExtraLabels:         flags.ExtraLabels,
+		Reviewers:           flags.Reviewers,
+		Assignees:           flags.Assignees,
 	}
 	createPullRequestUseCase := use_cases.CreatePullRequest{
 		Cfg:                     createPullRequestConfig,
@@ -111,7 +155,13 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		BranchProvider:          branchProvider,
 	}
 
-	return createPullRequestUseCase.Execute()
+	_, err = createPullRequestUseCase.Execute()
+	if err != nil && flags.OutputFormat == "json" {
+		errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
+		fmt.Fprintln(os.Stderr, string(errJSON))
+		os.Exit(1)
+	}
+	return err
 }
 
 func preRunCommand(cmd *cobra.Command, _ []string) error {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -45,6 +45,11 @@ gh sherpa create-branch, cb [flags]
 * `--fork`: Automatically set up fork for external contributors.
 * `--fork-name`: Specify custom fork organization/user (e.g. MyOrg/gh-sherpa).
 * `--prefer-hotfix`: Prefer hotfix branch prefix for bug issues when using non-interactive mode (`-y`). For GitHub issues, this flag checks if the `kind/bug` label is present **anywhere** in the issue's label list (not just as the first or primary label). When found, it creates a `hotfix/` branch instead of `bugfix/`, regardless of the issue's detected type or other labels present.
+* `--branch-type`: Force a specific branch type prefix (e.g. `feature`, `bugfix`, `hotfix`). Bypasses issue label detection and works in both interactive and non-interactive mode.
+* `--branch-description`: Force a specific branch description slug instead of deriving it from the issue title. Works in both interactive and non-interactive mode.
+* `--branch-name`: Use exactly this branch name without any auto-generation. Takes priority over all other naming flags.
+* `--dry-run`: Print what would happen without actually creating the branch.
+* `--output`: Output format. Use `json` to get machine-readable output `{"branch":"<name>"}`. Default is human-readable text.
 
 ### Possible scenarios
 
@@ -93,6 +98,24 @@ gh sherpa create-branch --issue 32 --fork
 gh sherpa create-branch --issue 45 --fork --fork-name MyOrg/gh-sherpa
 ```
 
+#### Create a branch with a specific type and description (AI-friendly)
+
+```sh
+# Force branch type and description without interactive prompts
+gh sherpa create-branch --issue 42 --yes --branch-type feature --branch-description "add-auth-endpoint"
+# Creates: feature/GH-42-add-auth-endpoint
+
+# Use an exact branch name
+gh sherpa create-branch --issue 42 --yes --branch-name "feature/GH-42-my-exact-name"
+
+# Preview what would be created
+gh sherpa create-branch --issue 42 --yes --branch-type feature --dry-run
+
+# Get machine-readable output for scripting
+gh sherpa create-branch --issue 42 --yes --branch-type feature --output json
+# Output: {"branch":"feature/GH-42-issue-title"}
+```
+
 ## Create pull request
 
 Create a pull request associated to a GitHub or Jira issue.
@@ -111,10 +134,22 @@ gh sherpa create-pr, cpr [flags]
 * `--yes, -y`: The pull request will be created without confirmation.
 * `--no-draft`: The pull request will be created in ready for review mode. By default is in draft mode.
 * `--no-close-issue`: The GitHub issue will not be closed when the pull request is merged. By default is closed.
-* `--template`: Path to a pull request template file
+* `--template`: Path to a pull request template file.
 * `--fork`: Automatically set up fork for external contributors.
 * `--fork-name`: Specify custom fork organization/user (e.g. MyOrg/gh-sherpa).
 * `--prefer-hotfix`: Prefer hotfix branch prefix for bug issues when using non-interactive mode (`-y`). For GitHub issues, this flag checks if the `kind/bug` label is present **anywhere** in the issue's label list (not just as the first or primary label). When found, it creates a `hotfix/` branch instead of `bugfix/`, regardless of the issue's detected type or other labels present.
+* `--branch-type`: Force a specific branch type prefix (e.g. `feature`, `bugfix`, `hotfix`). Bypasses issue label detection.
+* `--branch-description`: Force a specific branch description slug instead of deriving it from the issue title.
+* `--branch-name`: Use exactly this branch name without any auto-generation.
+* `--dry-run`: Print what would happen without actually creating the PR.
+* `--output`: Output format. Use `json` to get machine-readable output `{"branch":"<name>","pr_url":"<url>","draft":<bool>}`. Default is human-readable text.
+* `--pr-title`: Override the auto-generated PR title.
+* `--pr-body`: Override the auto-generated PR body.
+* `--pr-body-file`: Read the PR body from a file (overrides `--pr-body` and `--template`).
+* `--no-use-existing-branch`: Fail if a branch for this issue already exists (default non-interactive behavior is to reuse the existing branch).
+* `--label`: Additional label to apply to the PR. Can be repeated: `--label bug --label priority/high`.
+* `--reviewer`: Request a review from this user or team. Can be repeated: `--reviewer alice --reviewer org/team`.
+* `--assignee`: Assign this user to the PR. Can be repeated: `--assignee alice`.
 
 ### Possible scenarios
 
@@ -185,6 +220,34 @@ gh sherpa create-pr --issue 32 --fork
 
 # Custom fork organization
 gh sherpa create-pr --issue 45 --fork --fork-name MyOrg/gh-sherpa
+```
+
+#### Create a fully scripted PR (AI-friendly, zero interactive prompts)
+
+```sh
+# All parameters specified — no interactive prompts, no stdin required
+gh sherpa create-pr \
+  --issue 42 \
+  --yes \
+  --branch-type feature \
+  --branch-description "add-auth-endpoint" \
+  --pr-title "feat: add authentication endpoint" \
+  --pr-body "Closes #42" \
+  --reviewer alice \
+  --reviewer org/backend-team \
+  --assignee bob \
+  --label "priority/high" \
+  --no-draft
+
+# With JSON output for scripting
+gh sherpa create-pr --issue 42 --yes --branch-type bugfix --output json
+# Output: {"branch":"bugfix/GH-42-issue-title","pr_url":"https://...","draft":true}
+
+# Preview without executing
+gh sherpa create-pr --issue 42 --yes --branch-type feature --dry-run
+
+# Fail if a branch already exists (instead of reusing it)
+gh sherpa create-pr --issue 42 --yes --no-use-existing-branch
 ```
 
 ## Fork Configuration

--- a/internal/branches/branches.go
+++ b/internal/branches/branches.go
@@ -18,8 +18,10 @@ type BranchProvider struct {
 
 type Configuration struct {
 	config.Branches
-	IsInteractive bool
-	PreferHotfix  bool
+	IsInteractive     bool
+	PreferHotfix      bool
+	ForcedBranchType  string
+	ForcedDescription string
 }
 
 func NewFromConfiguration(globalConfig config.Configuration, userInteractionProvider domain.UserInteractionProvider, isInteractive bool) (*BranchProvider, error) {

--- a/internal/branches/branches_test.go
+++ b/internal/branches/branches_test.go
@@ -284,6 +284,48 @@ func (s *BranchTestSuite) TestGetBranchName() {
 		s.NoError(err)
 		s.Equal(expectedBrachName, branchName)
 	})
+
+	s.Run("should use forced branch type bypassing issue label detection", func() {
+		s.fakeIssue.SetType(issue_types.Bug)
+		s.b.cfg.ForcedBranchType = "feature"
+
+		branchName, err := s.b.GetBranchName(s.fakeIssue, *s.defaultRepository)
+
+		s.NoError(err)
+		s.Equal("feature/GH-1-fake-title", branchName)
+	})
+
+	s.Run("should use forced branch type for undetermined issue type without error", func() {
+		s.fakeIssue.SetType("undetermined-type")
+		s.b.cfg.ForcedBranchType = "hotfix"
+		s.b.cfg.Prefixes[issue_types.Hotfix] = "hotfix"
+
+		branchName, err := s.b.GetBranchName(s.fakeIssue, *s.defaultRepository)
+
+		s.NoError(err)
+		s.Equal("hotfix/GH-1-fake-title", branchName)
+	})
+
+	s.Run("should use forced description as slug instead of issue title", func() {
+		s.fakeIssue.SetType(issue_types.Bug)
+		s.b.cfg.ForcedDescription = "my custom description"
+
+		branchName, err := s.b.GetBranchName(s.fakeIssue, *s.defaultRepository)
+
+		s.NoError(err)
+		s.Equal("bugfix/GH-1-my-custom-description", branchName)
+	})
+
+	s.Run("should use forced description in interactive mode too", func() {
+		s.b.cfg.IsInteractive = true
+		s.b.cfg.ForcedDescription = "custom desc"
+		s.userInteractionProvider.EXPECT().SelectOrInputPrompt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+		branchName, err := s.b.GetBranchName(s.fakeIssue, *s.defaultRepository)
+
+		s.NoError(err)
+		s.Equal("bugfix/GH-1-custom-desc", branchName)
+	})
 }
 
 func TestParseIssueContext(t *testing.T) {

--- a/internal/branches/interactive.go
+++ b/internal/branches/interactive.go
@@ -24,26 +24,35 @@ func (b BranchProvider) GetBranchName(issue domain.Issue, repo domain.Repository
 
 	issueTrackerType := issue.TrackerType()
 
-	if b.cfg.IsInteractive {
+	// --branch-description overrides the slug in both interactive and non-interactive modes
+	if b.cfg.ForcedDescription != "" {
+		issueSlug = normalizeBranch(b.cfg.ForcedDescription)
+	}
+
+	// --branch-type bypasses all label/type detection
+	if b.cfg.ForcedBranchType != "" {
+		branchType = b.cfg.ForcedBranchType
+	} else if b.cfg.IsInteractive {
 		branchType, err = b.getBranchType(issueType, issueTrackerType)
 		if err != nil {
 			return "", err
 		}
 
-		truncatePrompt := ""
-		maxContextLen := b.calcIssueContextMaxLen(repo.NameWithOwner, branchType, formattedID)
-		if maxContextLen > 0 {
-			truncatePrompt = fmt.Sprintf(" Truncate to %d chars", maxContextLen)
+		if b.cfg.ForcedDescription == "" {
+			truncatePrompt := ""
+			maxContextLen := b.calcIssueContextMaxLen(repo.NameWithOwner, branchType, formattedID)
+			if maxContextLen > 0 {
+				truncatePrompt = fmt.Sprintf(" Truncate to %d chars", maxContextLen)
+			}
+
+			promptIssueContext := "additional description (optional)." + truncatePrompt
+			err = b.UserInteraction.SelectOrInput(promptIssueContext, []string{}, &issueSlug, false)
+			if err != nil {
+				return "", err
+			}
+
+			issueSlug = normalizeBranch(issueSlug)
 		}
-
-		promptIssueContext := "additional description (optional)." + truncatePrompt
-		err = b.UserInteraction.SelectOrInput(promptIssueContext, []string{}, &issueSlug, false)
-		if err != nil {
-			return "", err
-		}
-
-		issueSlug = normalizeBranch(issueSlug)
-
 	} else {
 		// Check for kind/bug label to determine if prefer-hotfix should apply
 		// This works regardless of the issue's determined type or label position
@@ -62,7 +71,7 @@ func (b BranchProvider) GetBranchName(issue domain.Issue, repo domain.Repository
 		}
 
 		if !issueType.Valid() || issueType == issue_types.Other || issueType == issue_types.Unknown {
-			return "", ErrUndeterminedIssueType
+			return "", fmt.Errorf("%w; use --branch-type to specify it", ErrUndeterminedIssueType)
 		}
 	}
 

--- a/internal/domain/providers.go
+++ b/internal/domain/providers.go
@@ -6,7 +6,7 @@ type RepositoryProvider interface {
 
 type PullRequestProvider interface {
 	GetPullRequestForBranch(branch string) (pullRequest *PullRequest, err error)
-	CreatePullRequest(title string, body string, baseBranch string, headBranch string, draft bool, labels []string) (prUrl string, err error)
+	CreatePullRequest(title string, body string, baseBranch string, headBranch string, draft bool, labels []string, reviewers []string, assignees []string) (prUrl string, err error)
 }
 
 type UserInteractionProvider interface {

--- a/internal/fakes/domain/fake_pull_request_provider.go
+++ b/internal/fakes/domain/fake_pull_request_provider.go
@@ -53,7 +53,7 @@ func ErrPrAlreadyExists(branch string) error {
 
 var ErrPullRequestWithError = errors.New("pull request with error")
 
-func (f *FakePullRequestProvider) CreatePullRequest(title string, body string, baseBranch string, headBranch string, draft bool, labels []string) (prUrl string, err error) {
+func (f *FakePullRequestProvider) CreatePullRequest(title string, body string, baseBranch string, headBranch string, draft bool, labels []string, reviewers []string, assignees []string) (prUrl string, err error) {
 	if slices.Contains(f.PullRequestsWithErrors, headBranch) {
 		return "", ErrPullRequestWithError
 	}

--- a/internal/gh/cli.go
+++ b/internal/gh/cli.go
@@ -108,7 +108,7 @@ var executeGitCommand = func(args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
-func (c *Cli) CreatePullRequest(title string, body string, baseBranch string, headBranch string, draft bool, labels []string) (prURL string, err error) {
+func (c *Cli) CreatePullRequest(title string, body string, baseBranch string, headBranch string, draft bool, labels []string, reviewers []string, assignees []string) (prURL string, err error) {
 	args := []string{"pr", "create"}
 
 	if baseBranch != "" {
@@ -145,6 +145,14 @@ func (c *Cli) CreatePullRequest(title string, body string, baseBranch string, he
 
 	// Add labels if not in fork context
 	args = c.addLabelsToArgs(args, labels)
+
+	for _, reviewer := range reviewers {
+		args = append(args, "--reviewer", reviewer)
+	}
+
+	for _, assignee := range assignees {
+		args = append(args, "--assignee", assignee)
+	}
 
 	result, err := ExecuteStringResult(args)
 

--- a/internal/gh/cli_test.go
+++ b/internal/gh/cli_test.go
@@ -65,7 +65,7 @@ func TestCli_CreatePullRequest(t *testing.T) {
 				return "https://github.com/InditexTech/gh-sherpa/pulls/1\n", nil
 			}
 
-			gotPrURL, err := c.CreatePullRequest(tt.args.title, tt.args.body, tt.args.baseBranch, tt.args.headBranch, tt.args.draft, tt.args.labels)
+			gotPrURL, err := c.CreatePullRequest(tt.args.title, tt.args.body, tt.args.baseBranch, tt.args.headBranch, tt.args.draft, tt.args.labels, nil, nil)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -203,7 +203,7 @@ func TestCli_CreatePullRequest_InForkContext(t *testing.T) {
 				return "https://github.com/InditexTech/gh-sherpa/pulls/1\n", nil
 			}
 
-			gotPrURL, err := c.CreatePullRequest(tt.title, tt.body, tt.baseBranch, tt.headBranch, tt.draft, tt.labels)
+			gotPrURL, err := c.CreatePullRequest(tt.title, tt.body, tt.baseBranch, tt.headBranch, tt.draft, tt.labels, nil, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/mocks/domain/mock_PullRequestProvider.go
+++ b/internal/mocks/domain/mock_PullRequestProvider.go
@@ -20,23 +20,23 @@ func (_m *MockPullRequestProvider) EXPECT() *MockPullRequestProvider_Expecter {
 	return &MockPullRequestProvider_Expecter{mock: &_m.Mock}
 }
 
-// CreatePullRequest provides a mock function with given fields: title, body, baseBranch, headBranch, draft, labels
-func (_m *MockPullRequestProvider) CreatePullRequest(title string, body string, baseBranch string, headBranch string, draft bool, labels []string) (string, error) {
-	ret := _m.Called(title, body, baseBranch, headBranch, draft, labels)
+// CreatePullRequest provides a mock function with given fields: title, body, baseBranch, headBranch, draft, labels, reviewers, assignees
+func (_m *MockPullRequestProvider) CreatePullRequest(title string, body string, baseBranch string, headBranch string, draft bool, labels []string, reviewers []string, assignees []string) (string, error) {
+	ret := _m.Called(title, body, baseBranch, headBranch, draft, labels, reviewers, assignees)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, []string) (string, error)); ok {
-		return rf(title, body, baseBranch, headBranch, draft, labels)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, []string, []string, []string) (string, error)); ok {
+		return rf(title, body, baseBranch, headBranch, draft, labels, reviewers, assignees)
 	}
-	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, []string) string); ok {
-		r0 = rf(title, body, baseBranch, headBranch, draft, labels)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, []string, []string, []string) string); ok {
+		r0 = rf(title, body, baseBranch, headBranch, draft, labels, reviewers, assignees)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string, string, string, bool, []string) error); ok {
-		r1 = rf(title, body, baseBranch, headBranch, draft, labels)
+	if rf, ok := ret.Get(1).(func(string, string, string, string, bool, []string, []string, []string) error); ok {
+		r1 = rf(title, body, baseBranch, headBranch, draft, labels, reviewers, assignees)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,13 +56,15 @@ type MockPullRequestProvider_CreatePullRequest_Call struct {
 //   - headBranch string
 //   - draft bool
 //   - labels []string
-func (_e *MockPullRequestProvider_Expecter) CreatePullRequest(title interface{}, body interface{}, baseBranch interface{}, headBranch interface{}, draft interface{}, labels interface{}) *MockPullRequestProvider_CreatePullRequest_Call {
-	return &MockPullRequestProvider_CreatePullRequest_Call{Call: _e.mock.On("CreatePullRequest", title, body, baseBranch, headBranch, draft, labels)}
+//   - reviewers []string
+//   - assignees []string
+func (_e *MockPullRequestProvider_Expecter) CreatePullRequest(title interface{}, body interface{}, baseBranch interface{}, headBranch interface{}, draft interface{}, labels interface{}, reviewers interface{}, assignees interface{}) *MockPullRequestProvider_CreatePullRequest_Call {
+	return &MockPullRequestProvider_CreatePullRequest_Call{Call: _e.mock.On("CreatePullRequest", title, body, baseBranch, headBranch, draft, labels, reviewers, assignees)}
 }
 
-func (_c *MockPullRequestProvider_CreatePullRequest_Call) Run(run func(title string, body string, baseBranch string, headBranch string, draft bool, labels []string)) *MockPullRequestProvider_CreatePullRequest_Call {
+func (_c *MockPullRequestProvider_CreatePullRequest_Call) Run(run func(title string, body string, baseBranch string, headBranch string, draft bool, labels []string, reviewers []string, assignees []string)) *MockPullRequestProvider_CreatePullRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string), args[3].(string), args[4].(bool), args[5].([]string))
+		run(args[0].(string), args[1].(string), args[2].(string), args[3].(string), args[4].(bool), args[5].([]string), args[6].([]string), args[7].([]string))
 	})
 	return _c
 }
@@ -72,7 +74,7 @@ func (_c *MockPullRequestProvider_CreatePullRequest_Call) Return(prUrl string, e
 	return _c
 }
 
-func (_c *MockPullRequestProvider_CreatePullRequest_Call) RunAndReturn(run func(string, string, string, string, bool, []string) (string, error)) *MockPullRequestProvider_CreatePullRequest_Call {
+func (_c *MockPullRequestProvider_CreatePullRequest_Call) RunAndReturn(run func(string, string, string, string, bool, []string, []string, []string) (string, error)) *MockPullRequestProvider_CreatePullRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/use_cases/create_branch.go
+++ b/internal/use_cases/create_branch.go
@@ -1,17 +1,26 @@
 package use_cases
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/InditexTech/gh-sherpa/internal/domain"
 	"github.com/InditexTech/gh-sherpa/internal/logging"
 )
 
+// CreateBranchResult holds the outcome of a successful CreateBranch execution.
+type CreateBranchResult struct {
+	BranchName string `json:"branch"`
+}
+
 type CreateBranchConfiguration struct {
-	IssueID         string
-	BaseBranch      string
-	FetchFromOrigin bool
-	IsInteractive   bool
+	IssueID          string
+	BaseBranch       string
+	FetchFromOrigin  bool
+	IsInteractive    bool
+	BranchName       string // --branch-name: bypass generation and use this name directly
+	DryRun           bool   // --dry-run: print what would happen without executing
+	OutputFormat     string // --output: "" (default) or "json"
 }
 
 type CreateBranch struct {
@@ -24,14 +33,14 @@ type CreateBranch struct {
 }
 
 // Execute executes the create branch use case
-func (cb CreateBranch) Execute() (err error) {
+func (cb CreateBranch) Execute() (result CreateBranchResult, err error) {
 	if cb.Cfg.IssueID == "" {
-		return fmt.Errorf("sherpa needs an valid issue identifier")
+		return result, fmt.Errorf("sherpa needs an valid issue identifier")
 	}
 
 	repo, err := cb.RepositoryProvider.GetRepository()
 	if err != nil {
-		return err
+		return result, err
 	}
 
 	baseBranch := cb.Cfg.BaseBranch
@@ -40,28 +49,64 @@ func (cb CreateBranch) Execute() (err error) {
 		baseBranch = repo.DefaultBranchRef
 	}
 
-	issue, err := cb.IssueTrackerProvider.GetIssue(cb.Cfg.IssueID)
-	if err != nil {
-		return err
+	var branchName string
+	if cb.Cfg.BranchName != "" {
+		branchName = cb.Cfg.BranchName
+	} else {
+		issue, err := cb.IssueTrackerProvider.GetIssue(cb.Cfg.IssueID)
+		if err != nil {
+			return result, err
+		}
+
+		branchName, err = cb.BranchProvider.GetBranchName(issue, *repo)
+		if err != nil {
+			return result, err
+		}
 	}
 
-	branchName, err := cb.BranchProvider.GetBranchName(issue, *repo)
-	if err != nil {
-		return err
+	result.BranchName = branchName
+
+	if cb.Cfg.DryRun {
+		if cb.Cfg.OutputFormat == "json" {
+			jsonBytes, jsonErr := json.Marshal(result)
+			if jsonErr != nil {
+				return result, fmt.Errorf("failed to serialize dry-run result: %w", jsonErr)
+			}
+			fmt.Println(string(jsonBytes))
+		} else {
+			fmt.Printf("[dry-run] Would create branch: %s from %s\n", logging.PaintInfo(branchName), logging.PaintInfo(baseBranch))
+		}
+		return result, nil
 	}
 
-	fmt.Printf("\nA new local branch named %s is going to be created\n", logging.PaintInfo(branchName))
+	if cb.Cfg.OutputFormat != "json" {
+		fmt.Printf("\nA new local branch named %s is going to be created\n", logging.PaintInfo(branchName))
+	}
 	if cb.Cfg.IsInteractive {
 		confirmed, err := cb.UserInteractionProvider.AskUserForConfirmation("Do you want to continue?", true)
 		if err != nil {
-			return err
+			return result, err
 		}
 		if !confirmed {
-			return nil
+			return result, nil
 		}
 	}
 
-	return cb.checkoutBranch(branchName, baseBranch, !cb.Cfg.FetchFromOrigin)
+	if err := cb.checkoutBranch(branchName, baseBranch, !cb.Cfg.FetchFromOrigin); err != nil {
+		return result, err
+	}
+
+	if cb.Cfg.OutputFormat == "json" {
+		jsonBytes, jsonErr := json.Marshal(result)
+		if jsonErr != nil {
+			return result, fmt.Errorf("failed to serialize result: %w", jsonErr)
+		}
+		fmt.Println(string(jsonBytes))
+	} else {
+		fmt.Printf("A local branch named %s has been created!\n", logging.PaintInfo(branchName))
+	}
+
+	return result, nil
 }
 
 func (cb CreateBranch) checkoutBranch(branchName string, baseBranch string, fetch bool) error {
@@ -78,8 +123,6 @@ func (cb CreateBranch) checkoutBranch(branchName string, baseBranch string, fetc
 	if err := cb.Git.CheckoutNewBranchFromOrigin(branchName, baseBranch); err != nil {
 		return err
 	}
-
-	fmt.Printf("A local branch named %s has been created!\n", logging.PaintInfo(branchName))
 
 	return nil
 }

--- a/internal/use_cases/create_branch.go
+++ b/internal/use_cases/create_branch.go
@@ -14,13 +14,13 @@ type CreateBranchResult struct {
 }
 
 type CreateBranchConfiguration struct {
-	IssueID          string
-	BaseBranch       string
-	FetchFromOrigin  bool
-	IsInteractive    bool
-	BranchName       string // --branch-name: bypass generation and use this name directly
-	DryRun           bool   // --dry-run: print what would happen without executing
-	OutputFormat     string // --output: "" (default) or "json"
+	IssueID         string
+	BaseBranch      string
+	FetchFromOrigin bool
+	IsInteractive   bool
+	BranchName      string // --branch-name: bypass generation and use this name directly
+	DryRun          bool   // --dry-run: print what would happen without executing
+	OutputFormat    string // --output: "" (default) or "json"
 }
 
 type CreateBranch struct {

--- a/internal/use_cases/create_branch_test.go
+++ b/internal/use_cases/create_branch_test.go
@@ -75,14 +75,14 @@ func (s *CreateGithubBranchExecutionTestSuite) TestCreateBranchExecution() {
 
 		s.uc.Cfg.IssueID = "1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.Error(err)
 		s.False(s.gitProvider.BranchExists(s.defaultBranchName))
 	})
 
 	s.Run("should error if no issue flag is provided", func() {
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "sherpa needs an valid issue identifier")
 		s.False(s.gitProvider.BranchExists(s.defaultBranchName))
@@ -96,7 +96,7 @@ func (s *CreateGithubBranchExecutionTestSuite) TestCreateBranchExecution() {
 		s.uc.Cfg.IssueID = "3"
 		s.uc.Cfg.IsInteractive = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, fmt.Sprintf("a local branch with the name %s already exists", branchName))
 	})
@@ -105,7 +105,7 @@ func (s *CreateGithubBranchExecutionTestSuite) TestCreateBranchExecution() {
 		s.uc.Cfg.IssueID = "1"
 		s.uc.Cfg.IsInteractive = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.gitProvider.BranchExists(s.defaultBranchName))
@@ -116,7 +116,7 @@ func (s *CreateGithubBranchExecutionTestSuite) TestCreateBranchExecution() {
 		s.userInteractionProvider.EXPECT().AskUserForConfirmation("Do you want to continue?", true).Return(true, nil).Maybe()
 		s.uc.Cfg.IssueID = "1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.gitProvider.BranchExists(s.defaultBranchName))
@@ -132,7 +132,7 @@ func (s *CreateGithubBranchExecutionTestSuite) TestCreateBranchExecution() {
 
 		s.uc.Cfg.IssueID = "3"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, fmt.Sprintf("a local branch with the name %s already exists", branchName))
 	})
@@ -195,14 +195,14 @@ func (s *CreateJiraBranchExecutionTestSuite) TestCreateBranchExecution() {
 
 		s.uc.Cfg.IssueID = issueID
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.Error(err)
 		s.False(s.gitProvider.BranchExists(s.defaultBranchName))
 	})
 
 	s.Run("should error if no issue flag is provided", func() {
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "sherpa needs an valid issue identifier")
 		s.False(s.gitProvider.BranchExists(s.defaultBranchName))
@@ -216,7 +216,7 @@ func (s *CreateJiraBranchExecutionTestSuite) TestCreateBranchExecution() {
 		s.uc.Cfg.IssueID = "PROJECTKEY-3"
 		s.uc.Cfg.IsInteractive = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, fmt.Sprintf("a local branch with the name %s already exists", branchName))
 	})
@@ -225,7 +225,7 @@ func (s *CreateJiraBranchExecutionTestSuite) TestCreateBranchExecution() {
 		s.uc.Cfg.IssueID = issueID
 		s.uc.Cfg.IsInteractive = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.gitProvider.BranchExists(s.defaultBranchName))
@@ -236,7 +236,7 @@ func (s *CreateJiraBranchExecutionTestSuite) TestCreateBranchExecution() {
 		s.userInteractionProvider.EXPECT().AskUserForConfirmation("Do you want to continue?", true).Return(true, nil).Maybe()
 		s.uc.Cfg.IssueID = issueID
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.gitProvider.BranchExists(s.defaultBranchName))
@@ -252,7 +252,7 @@ func (s *CreateJiraBranchExecutionTestSuite) TestCreateBranchExecution() {
 
 		s.uc.Cfg.IssueID = issueID
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, fmt.Sprintf("a local branch with the name %s already exists", branchName))
 	})

--- a/internal/use_cases/create_pull_request.go
+++ b/internal/use_cases/create_pull_request.go
@@ -1,6 +1,7 @@
 package use_cases
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -27,15 +28,32 @@ func ErrPushChanges(branch string, err error) error {
 	return fmt.Errorf("could not push to remote branch %s: %w", branch, err)
 }
 
+// CreatePullRequestResult holds the outcome of a successful CreatePullRequest execution.
+type CreatePullRequestResult struct {
+	BranchName string `json:"branch"`
+	PRURL      string `json:"pr_url"`
+	Draft      bool   `json:"draft"`
+}
+
 // CreatePullRequestConfiguration contains the arguments for the CreatePullRequest use case
 type CreatePullRequestConfiguration struct {
-	IssueID         string
-	BaseBranch      string
-	FetchFromOrigin bool
-	DraftPR         bool
-	IsInteractive   bool
-	CloseIssue      bool
-	TemplatePath    string
+	IssueID            string
+	BaseBranch         string
+	FetchFromOrigin    bool
+	DraftPR            bool
+	IsInteractive      bool
+	CloseIssue         bool
+	TemplatePath       string
+	BranchName         string   // --branch-name: bypass generation and use this name directly
+	DryRun             bool     // --dry-run: print what would happen without executing
+	OutputFormat       string   // --output: "" (default) or "json"
+	PRTitle            string   // --pr-title: override the auto-generated PR title
+	PRBody             string   // --pr-body: override the auto-generated PR body
+	PRBodyFile         string   // --pr-body-file: read PR body from file
+	NoUseExistingBranch bool    // --no-use-existing-branch: fail if a branch already exists (non-interactive)
+	ExtraLabels        []string // --label: additional labels to apply to the PR
+	Reviewers          []string // --reviewer: PR reviewers
+	Assignees          []string // --assignee: PR assignees
 }
 
 type CreatePullRequest struct {
@@ -86,19 +104,25 @@ func validateTemplateFile(templatePath string, git domain.GitProvider) error {
 }
 
 // Execute executes the create pull request use case
-func (cpr CreatePullRequest) Execute() error {
+func (cpr CreatePullRequest) Execute() (result CreatePullRequestResult, err error) {
 	// Validate template if specified
 	if err := validateTemplateFile(cpr.Cfg.TemplatePath, cpr.Git); err != nil {
-		return err
+		return result, err
 	}
 
 	isInteractive := cpr.Cfg.IsInteractive
+	// --output json implies non-interactive: no stdin prompts must appear in JSON output.
+	if cpr.Cfg.OutputFormat == "json" {
+		isInteractive = false
+	}
+	// Normalize so helper methods that read cpr.Cfg.IsInteractive also see the effective value.
+	cpr.Cfg.IsInteractive = isInteractive
 	fromLocalBranch := cpr.Cfg.IssueID == ""
 
 	repo, err := cpr.RepositoryProvider.GetRepository()
 	if err != nil {
 		logging.Debugf("error while getting repo: %s", err)
-		return err
+		return result, err
 	}
 
 	baseBranch := cpr.Cfg.BaseBranch
@@ -106,19 +130,19 @@ func (cpr CreatePullRequest) Execute() error {
 		baseBranch = repo.DefaultBranchRef
 	}
 	if err := cpr.fetchBranch(baseBranch); err != nil {
-		return err
+		return result, err
 	}
 
 	currentBranch, err := cpr.Git.GetCurrentBranch()
 	if err != nil {
-		return fmt.Errorf("could not get the current branch name because %s", err)
+		return result, fmt.Errorf("could not get the current branch name because %s", err)
 	}
 
 	var issueID string
 	if fromLocalBranch {
 		issueID, err = cpr.extractIssueIdFromBranch(currentBranch)
 		if err != nil {
-			return err
+			return result, err
 		}
 	} else {
 		issueID = cpr.Cfg.IssueID
@@ -126,7 +150,7 @@ func (cpr CreatePullRequest) Execute() error {
 
 	issue, err := cpr.IssueTrackerProvider.GetIssue(issueID)
 	if err != nil {
-		return err
+		return result, err
 	}
 
 	var branchExists bool
@@ -138,11 +162,15 @@ func (cpr CreatePullRequest) Execute() error {
 
 		if branchExists {
 			if !isInteractive {
-				return fmt.Errorf("the branch %s already exists", logging.PaintWarning(currentBranch))
+				if cpr.Cfg.NoUseExistingBranch {
+					return result, fmt.Errorf("the branch %s already exists", logging.PaintWarning(currentBranch))
+				}
+				// Default non-interactive behavior: reuse the existing branch silently
+				logging.Debugf("Reusing existing branch %s", currentBranch)
+			} else {
+				logging.PrintWarn(
+					fmt.Sprintf("there is already a local branch named %s for this issue", logging.PaintInfo(currentBranch)))
 			}
-
-			logging.PrintWarn(
-				fmt.Sprintf("there is already a local branch named %s for this issue", logging.PaintInfo(currentBranch)))
 		}
 	}
 
@@ -151,12 +179,12 @@ func (cpr CreatePullRequest) Execute() error {
 		branchConfirmed, err = cpr.UserInteractionProvider.AskUserForConfirmation(
 			"Do you want to use this branch to create the pull request", true)
 		if err != nil {
-			return err
+			return result, err
 		}
 
 		if fromLocalBranch && !branchConfirmed {
 			// Clean exit since user do not want to continue
-			return nil
+			return result, nil
 		}
 	}
 
@@ -166,12 +194,12 @@ func (cpr CreatePullRequest) Execute() error {
 
 	if branchExists && branchConfirmed {
 		if err := cpr.Git.CheckoutBranch(currentBranch); err != nil {
-			return fmt.Errorf("could not switch to the branch because %w", err)
+			return result, fmt.Errorf("could not switch to the branch because %w", err)
 		}
 	} else {
 		currentBranch, err = cpr.BranchProvider.GetBranchName(issue, *repo)
 		if err != nil {
-			return err
+			return result, err
 		}
 
 		// After stablishing the branch, fetch it to get the latest changes.
@@ -181,55 +209,92 @@ func (cpr CreatePullRequest) Execute() error {
 
 		cancel, err := cpr.createBranch(currentBranch, baseBranch)
 		if err != nil {
-			return err
+			return result, err
 		}
 		if cancel {
-			return nil
+			return result, nil
 		}
 	}
 
 	hasPendingCommits, err := cpr.hasPendingCommits(currentBranch)
 	if err != nil {
-		return err
+		return result, err
 	}
 
 	if hasPendingCommits {
-		logging.PrintWarn("the branch contains commits that have not been pushed yet")
+		if cpr.Cfg.OutputFormat != "json" {
+			logging.PrintWarn("the branch contains commits that have not been pushed yet")
+		}
 
 		if isInteractive {
 			confirmed, err := cpr.UserInteractionProvider.AskUserForConfirmation(
 				"Do you want to continue pushing all pending commits in this branch and create the pull request", true)
 			if err != nil {
-				return err
+				return result, err
 			}
 			if !confirmed {
-				return nil
+				return result, nil
 			}
 		}
-	} else if !cpr.Git.RemoteBranchExists(currentBranch) {
+	}
+
+	// Early exit for dry-run: report what would happen without touching the remote.
+	if cpr.Cfg.DryRun {
+		result.BranchName = currentBranch
+		result.Draft = cpr.Cfg.DraftPR
+		if cpr.Cfg.OutputFormat == "json" {
+			jsonBytes, jsonErr := json.Marshal(result)
+			if jsonErr != nil {
+				return result, fmt.Errorf("failed to serialize dry-run result: %w", jsonErr)
+			}
+			fmt.Println(string(jsonBytes))
+		} else {
+			fmt.Printf("[dry-run] Would create PR from %s to %s\n",
+				logging.PaintInfo(currentBranch), logging.PaintInfo(baseBranch))
+		}
+		return result, nil
+	}
+
+	if !hasPendingCommits && !cpr.Git.RemoteBranchExists(currentBranch) {
 		if err = cpr.createEmptyCommit(); err != nil {
-			return fmt.Errorf("could not do the empty commit because %s", err)
+			return result, fmt.Errorf("could not do the empty commit because %s", err)
 		}
 	}
 
 	if err := cpr.pushChanges(currentBranch); err != nil {
-		return err
+		return result, err
 	}
 
 	pr, err := cpr.PullRequestProvider.GetPullRequestForBranch(currentBranch)
 	if err != nil {
-		return fmt.Errorf("error while getting pull request for branch: %w", err)
+		return result, fmt.Errorf("error while getting pull request for branch: %w", err)
 	}
 
 	if pr != nil && !pr.Closed {
-		return fmt.Errorf("a pull request %s for this branch already exists", pr.Url)
+		return result, fmt.Errorf("a pull request %s for this branch already exists", pr.Url)
 	}
 
-	if err := cpr.createPullRequestFromIssue(issue, baseBranch, currentBranch); err != nil {
-		return err
+	prURL, err := cpr.createPullRequestFromIssue(issue, baseBranch, currentBranch)
+	if err != nil {
+		return result, err
 	}
 
-	return nil
+	result.BranchName = currentBranch
+	result.PRURL = prURL
+	result.Draft = cpr.Cfg.DraftPR
+
+	if cpr.Cfg.OutputFormat == "json" {
+		jsonBytes, jsonErr := json.Marshal(result)
+		if jsonErr != nil {
+			return result, fmt.Errorf("failed to serialize result: %w", jsonErr)
+		}
+		fmt.Println(string(jsonBytes))
+	} else {
+		fmt.Printf("\nThe pull request %s have been created!\nYou are now working on the branch %s\n",
+			logging.PaintInfo(prURL), logging.PaintInfo(currentBranch))
+	}
+
+	return result, nil
 }
 
 func (cpr *CreatePullRequest) extractIssueIdFromBranch(currentBranch string) (string, error) {
@@ -238,7 +303,9 @@ func (cpr *CreatePullRequest) extractIssueIdFromBranch(currentBranch string) (st
 		return "", fmt.Errorf("could not find an issue identifier in the current branch named %s", logging.PaintWarning(currentBranch))
 	}
 
-	logging.PrintInfo(fmt.Sprintf("The current branch named %s is available to create a pull request", logging.PaintWarning(currentBranch)))
+	if cpr.Cfg.OutputFormat != "json" {
+		logging.PrintInfo(fmt.Sprintf("The current branch named %s is available to create a pull request", logging.PaintWarning(currentBranch)))
+	}
 
 	return cpr.IssueTrackerProvider.ParseIssueId(branchNameInfo.IssueId), nil
 }
@@ -258,6 +325,33 @@ func (cpr *CreatePullRequest) pushChanges(branchName string) (err error) {
 }
 
 func (cpr *CreatePullRequest) getPullRequestTitleAndBody(issue domain.Issue) (title string, body string, err error) {
+	// --pr-title and --pr-body fully override auto-generation
+	if cpr.Cfg.PRTitle != "" {
+		title = cpr.Cfg.PRTitle
+		body = cpr.Cfg.PRBody
+		return
+	}
+
+	// --pr-body-file overrides the body
+	if cpr.Cfg.PRBodyFile != "" {
+		content, readErr := os.ReadFile(cpr.Cfg.PRBodyFile)
+		if readErr != nil {
+			err = fmt.Errorf("failed to read --pr-body-file: %w", readErr)
+			return
+		}
+		body = string(content)
+		// Still auto-generate the title from the issue
+		switch issue.TrackerType() {
+		case domain.IssueTrackerTypeGithub:
+			title = issue.Title()
+		case domain.IssueTrackerTypeJira:
+			title = fmt.Sprintf("[%s] %s", issue.ID(), issue.Title())
+		default:
+			err = fmt.Errorf("issue tracker %s is not supported", issue.TrackerType())
+		}
+		return
+	}
+
 	// Determine base title and issue reference body based on tracker type
 	switch issue.TrackerType() {
 	case domain.IssueTrackerTypeGithub:
@@ -275,6 +369,12 @@ func (cpr *CreatePullRequest) getPullRequestTitleAndBody(issue domain.Issue) (ti
 
 	default:
 		return "", "", fmt.Errorf("issue tracker %s is not supported", issue.TrackerType())
+	}
+
+	// --pr-body overrides only the body (when --pr-title is not set)
+	if cpr.Cfg.PRBody != "" {
+		body = cpr.Cfg.PRBody
+		return
 	}
 
 	// If template path is provided, read and append it after the issue reference
@@ -335,8 +435,10 @@ func (cpr *CreatePullRequest) createBranch(branch string, baseBranch string) (ca
 		return
 	}
 
-	fmt.Printf("\nA new pull request is going to be created from %s to %s branch\n",
-		logging.PaintInfo(branch), logging.PaintInfo(baseBranch))
+	if cpr.Cfg.OutputFormat != "json" {
+		fmt.Printf("\nA new pull request is going to be created from %s to %s branch\n",
+			logging.PaintInfo(branch), logging.PaintInfo(baseBranch))
+	}
 
 	if cpr.Cfg.IsInteractive {
 		var confirmed bool
@@ -357,10 +459,10 @@ func (cpr *CreatePullRequest) createBranch(branch string, baseBranch string) (ca
 	return
 }
 
-func (cpr *CreatePullRequest) createPullRequestFromIssue(issue domain.Issue, baseBranch string, headBranch string) error {
+func (cpr *CreatePullRequest) createPullRequestFromIssue(issue domain.Issue, baseBranch string, headBranch string) (prURL string, err error) {
 	title, body, err := cpr.getPullRequestTitleAndBody(issue)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	labels := []string{}
@@ -368,14 +470,12 @@ func (cpr *CreatePullRequest) createPullRequestFromIssue(issue domain.Issue, bas
 	if typeLabel != "" {
 		labels = append(labels, typeLabel)
 	}
+	labels = append(labels, cpr.Cfg.ExtraLabels...)
 
-	prURL, err := cpr.PullRequestProvider.CreatePullRequest(title, body, baseBranch, headBranch, cpr.Cfg.DraftPR, labels)
+	prURL, err = cpr.PullRequestProvider.CreatePullRequest(title, body, baseBranch, headBranch, cpr.Cfg.DraftPR, labels, cpr.Cfg.Reviewers, cpr.Cfg.Assignees)
 	if err != nil {
-		return fmt.Errorf("could not create the pull request because %s", err)
+		return "", fmt.Errorf("could not create the pull request because %s", err)
 	}
 
-	fmt.Printf("\nThe pull request %s have been created!\nYou are now working on the branch %s\n",
-		logging.PaintInfo(prURL), logging.PaintInfo(headBranch))
-
-	return nil
+	return prURL, nil
 }

--- a/internal/use_cases/create_pull_request.go
+++ b/internal/use_cases/create_pull_request.go
@@ -37,23 +37,23 @@ type CreatePullRequestResult struct {
 
 // CreatePullRequestConfiguration contains the arguments for the CreatePullRequest use case
 type CreatePullRequestConfiguration struct {
-	IssueID            string
-	BaseBranch         string
-	FetchFromOrigin    bool
-	DraftPR            bool
-	IsInteractive      bool
-	CloseIssue         bool
-	TemplatePath       string
-	BranchName         string   // --branch-name: bypass generation and use this name directly
-	DryRun             bool     // --dry-run: print what would happen without executing
-	OutputFormat       string   // --output: "" (default) or "json"
-	PRTitle            string   // --pr-title: override the auto-generated PR title
-	PRBody             string   // --pr-body: override the auto-generated PR body
-	PRBodyFile         string   // --pr-body-file: read PR body from file
-	NoUseExistingBranch bool    // --no-use-existing-branch: fail if a branch already exists (non-interactive)
-	ExtraLabels        []string // --label: additional labels to apply to the PR
-	Reviewers          []string // --reviewer: PR reviewers
-	Assignees          []string // --assignee: PR assignees
+	IssueID             string
+	BaseBranch          string
+	FetchFromOrigin     bool
+	DraftPR             bool
+	IsInteractive       bool
+	CloseIssue          bool
+	TemplatePath        string
+	BranchName          string   // --branch-name: bypass generation and use this name directly
+	DryRun              bool     // --dry-run: print what would happen without executing
+	OutputFormat        string   // --output: "" (default) or "json"
+	PRTitle             string   // --pr-title: override the auto-generated PR title
+	PRBody              string   // --pr-body: override the auto-generated PR body
+	PRBodyFile          string   // --pr-body-file: read PR body from file
+	NoUseExistingBranch bool     // --no-use-existing-branch: fail if a branch already exists (non-interactive)
+	ExtraLabels         []string // --label: additional labels to apply to the PR
+	Reviewers           []string // --reviewer: PR reviewers
+	Assignees           []string // --assignee: PR assignees
 }
 
 type CreatePullRequest struct {

--- a/internal/use_cases/create_pull_request_test.go
+++ b/internal/use_cases/create_pull_request_test.go
@@ -83,7 +83,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 	s.Run("should error if could not get git repository", func() {
 		s.repositoryProvider.Repository = nil
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorIs(err, domainFakes.ErrRepositoryNotFound)
 	})
@@ -91,7 +91,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 	s.Run("should error if could not get current branch", func() {
 		s.gitProvider.CurrentBranch = ""
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "could not get the current branch name")
 		s.False(s.pullRequestProvider.HasPullRequestForBranch(s.gitProvider.CurrentBranch))
@@ -104,7 +104,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.gitProvider.AddLocalBranches(branchName)
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		expectedError := fmt.Sprintf("could not find an issue identifier in the current branch named %s", branchName)
 		s.EqualError(err, expectedError)
@@ -117,7 +117,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		mocks.UnsetExpectedCall(&s.userInteractionProvider.Mock, s.userInteractionProvider.AskUserForConfirmation)
 		s.userInteractionProvider.EXPECT().AskUserForConfirmation(mock.Anything, mock.Anything).Return(false, nil).Once()
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.False(s.pullRequestProvider.HasPullRequestForBranch(s.defaultBranchName))
@@ -130,7 +130,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.pullRequestProvider.AddPullRequest(branchName, domain.PullRequest{})
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "pull request")
 		s.ErrorContains(err, "already exists")
@@ -143,7 +143,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.branchProvider.SetBranchName(branchName)
 		s.uc.Cfg.IsInteractive = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertNotCalled(s.T(), "AskUserForConfirmation")
@@ -155,7 +155,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.gitProvider.AddLocalBranches(branchName)
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 	})
@@ -166,7 +166,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.gitProvider.AddLocalBranches(branchName)
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "could not push to remote branch "+branchName)
 		s.False(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -181,7 +181,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 
 		s.userInteractionProvider.EXPECT().AskUserForConfirmation("Do you want to continue pushing all pending commits in this branch and create the pull request", true).Return(false, nil).Once()
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -196,7 +196,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.gitProvider.CommitsToPush[branchName] = []string{"commit 1", "commit 2"}
 		s.uc.Cfg.IsInteractive = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertNotCalled(s.T(), "AskUserForConfirmation")
@@ -209,7 +209,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.gitProvider.BranchWithCommitError = []string{s.defaultBranchName}
 		s.branchProvider.SetBranchName(s.defaultBranchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorIs(err, domainFakes.ErrGetCommitsToPush)
 	})
@@ -220,7 +220,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.branchProvider.SetBranchName(s.defaultBranchName)
 		s.gitProvider.BranchWithPushError = []string{s.defaultBranchName}
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "could not push to remote branch "+s.defaultBranchName)
 	})
@@ -232,7 +232,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.pullRequestProvider.PullRequestsWithErrors = []string{branchName}
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "could not create the pull request because")
 	})
@@ -244,19 +244,31 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 
 		s.uc.Cfg.IssueID = "1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
 	})
 
-	s.Run("should error if branch already exists when using default and issue flags", func() {
+	s.Run("should reuse existing branch when using default and issue flags in non-interactive mode", func() {
+		s.gitProvider.ResetRemoteBranches()
 		s.uc.Cfg.IsInteractive = false
 		s.uc.Cfg.IssueID = "1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
+
+		s.NoError(err)
+	})
+
+	s.Run("should error if branch already exists when using no-use-existing-branch flag", func() {
+		s.uc.Cfg.IsInteractive = false
+		s.uc.Cfg.IssueID = "1"
+		s.uc.Cfg.NoUseExistingBranch = true
+
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "the branch feature/GH-1-sample-issue already exists")
+		s.uc.Cfg.NoUseExistingBranch = false
 	})
 
 	s.Run("should return error if remote branch already exists when using issue flags", func() {
@@ -265,7 +277,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 
 		s.uc.Cfg.IssueID = "1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, use_cases.ErrRemoteBranchAlreadyExists("feature/GH-1-sample-issue").Error())
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -281,7 +293,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 
 		s.uc.Cfg.IssueID = "1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -296,7 +308,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 
 		s.uc.Cfg.IssueID = "1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -311,7 +323,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 
 		s.uc.Cfg.IssueID = "1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -324,7 +336,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -343,7 +355,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 
 		s.uc.Cfg.IssueID = "1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(s.gitProvider.CurrentBranch))
@@ -357,7 +369,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 
 		s.uc.Cfg.CloseIssue = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -373,7 +385,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		// Set invalid template path
 		s.uc.Cfg.TemplatePath = "non_existent_template.md"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		// Should error early with template not found error
 		s.Error(err)
@@ -391,7 +403,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		// Usar una ruta relativa
 		s.uc.Cfg.TemplatePath = "testdata/test_template.md"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -413,7 +425,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		dir, _ := os.Getwd()
 		s.uc.Cfg.TemplatePath = filepath.Join(dir, "testdata", "test_template.md")
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -437,7 +449,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.uc.Cfg.TemplatePath = templatePath
 		s.uc.Cfg.CloseIssue = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -455,7 +467,7 @@ func (s *CreateGithubPullRequestExecutionTestSuite) TestCreatePullRequestExecuti
 		s.gitProvider.CurrentBranch = branchName
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.Error(err)
 		s.False(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -544,7 +556,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 	s.Run("should error if could not get git repository", func() {
 		s.repositoryProvider.Repository = nil
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorIs(err, domainFakes.ErrRepositoryNotFound)
 	})
@@ -552,7 +564,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 	s.Run("should error if could not get current branch", func() {
 		s.gitProvider.CurrentBranch = ""
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "could not get the current branch name")
 		s.False(s.pullRequestProvider.HasPullRequestForBranch(s.gitProvider.CurrentBranch))
@@ -563,7 +575,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.gitProvider.CurrentBranch = branchName
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		expectedError := fmt.Sprintf("could not find an issue identifier in the current branch named %s", branchName)
 		s.EqualError(err, expectedError)
@@ -576,7 +588,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		mocks.UnsetExpectedCall(&s.userInteractionProvider.Mock, s.userInteractionProvider.AskUserForConfirmation)
 		s.userInteractionProvider.EXPECT().AskUserForConfirmation(mock.Anything, mock.Anything).Return(false, nil).Once()
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.False(s.pullRequestProvider.HasPullRequestForBranch(s.defaultBranchName))
@@ -589,7 +601,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.pullRequestProvider.AddPullRequest(branchName, domain.PullRequest{})
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "pull request")
 		s.ErrorContains(err, "already exists")
@@ -602,7 +614,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.branchProvider.SetBranchName(branchName)
 		s.uc.Cfg.IsInteractive = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertNotCalled(s.T(), "AskUserForConfirmation")
@@ -614,7 +626,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.gitProvider.AddLocalBranches(branchName)
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 	})
@@ -624,7 +636,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.gitProvider.CurrentBranch = branchName
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "could not push to remote branch "+branchName)
 		s.False(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -639,7 +651,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.userInteractionProvider.EXPECT().AskUserForConfirmation("Do you want to continue pushing all pending commits in this branch and create the pull request", true).Return(false, nil).Once()
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -654,7 +666,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.gitProvider.CommitsToPush[branchName] = []string{"commit 1", "commit 2"}
 		s.uc.Cfg.IsInteractive = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertNotCalled(s.T(), "AskUserForConfirmation")
@@ -667,7 +679,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.gitProvider.BranchWithCommitError = []string{s.defaultBranchName}
 		s.branchProvider.SetBranchName(s.defaultBranchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorIs(err, domainFakes.ErrGetCommitsToPush)
 	})
@@ -678,7 +690,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.gitProvider.CurrentBranch = s.defaultBranchName
 		s.branchProvider.SetBranchName(s.defaultBranchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "could not push to remote branch "+s.defaultBranchName)
 	})
@@ -690,7 +702,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.pullRequestProvider.PullRequestsWithErrors = []string{branchName}
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "could not create the pull request because")
 	})
@@ -703,19 +715,31 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.uc.Cfg.IssueID = "PROJECTKEY-1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
 	})
 
-	s.Run("should error if branch already exists when using default and issue flags", func() {
+	s.Run("should reuse existing branch when using default and issue flags in non-interactive mode", func() {
+		s.gitProvider.ResetRemoteBranches()
 		s.uc.Cfg.IssueID = "PROJECTKEY-1"
 		s.uc.Cfg.IsInteractive = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
+
+		s.NoError(err)
+	})
+
+	s.Run("should error if branch already exists when using no-use-existing-branch flag", func() {
+		s.uc.Cfg.IssueID = "PROJECTKEY-1"
+		s.uc.Cfg.IsInteractive = false
+		s.uc.Cfg.NoUseExistingBranch = true
+
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, "the branch feature/PROJECTKEY-1-sample-issue already exists")
+		s.uc.Cfg.NoUseExistingBranch = false
 	})
 
 	s.Run("should return error if remote branch already exists when using issue flags", func() {
@@ -724,7 +748,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.uc.Cfg.IssueID = "PROJECTKEY-1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.ErrorContains(err, use_cases.ErrRemoteBranchAlreadyExists("feature/PROJECTKEY-1-sample-issue").Error())
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -740,7 +764,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.uc.Cfg.IssueID = "PROJECTKEY-1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -756,7 +780,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.uc.Cfg.IssueID = "PROJECTKEY-1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -771,7 +795,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.uc.Cfg.IssueID = "PROJECTKEY-1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.userInteractionProvider.AssertExpectations(s.T())
@@ -781,7 +805,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.gitProvider.RemoteBranches = []string{"main", "develop"}
 		s.gitProvider.CurrentBranch = "feature/PROJECTKEY-1-sample-issue"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(s.gitProvider.CurrentBranch))
@@ -800,7 +824,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.uc.Cfg.IssueID = "PROJECTKEY-1"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(s.gitProvider.CurrentBranch))
@@ -816,7 +840,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.uc.Cfg.CloseIssue = false
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 	})
@@ -831,7 +855,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		// Set invalid template path
 		s.uc.Cfg.TemplatePath = "non_existent_template.md"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		// Should error early with template not found error
 		s.Error(err)
@@ -848,7 +872,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 
 		s.uc.Cfg.TemplatePath = "testdata/test_template.md"
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -868,7 +892,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		dir, _ := os.Getwd()
 		s.uc.Cfg.TemplatePath = filepath.Join(dir, "testdata", "test_template.md")
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -890,7 +914,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		templatePath := filepath.Join(dir, "testdata", "test_template.md")
 		s.uc.Cfg.TemplatePath = templatePath
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.NoError(err)
 		s.True(s.pullRequestProvider.HasPullRequestForBranch(branchName))
@@ -908,7 +932,7 @@ func (s *CreateJiraPullRequestExecutionTestSuite) TestCreatePullRequestExecution
 		s.gitProvider.CurrentBranch = branchName
 		s.branchProvider.SetBranchName(branchName)
 
-		err := s.uc.Execute()
+		_, err := s.uc.Execute()
 
 		s.Error(err)
 		s.False(s.pullRequestProvider.HasPullRequestForBranch(branchName))


### PR DESCRIPTION
## Summary

This PR implements all AI-friendliness improvements proposed in issue #156 to make `gh sherpa` fully drivable by AI coding agents and CI pipelines — zero interactive stdin prompts needed.

## Changes

### `create-branch` new flags
- `--branch-type`: Force branch type prefix (e.g. `feature`, `bugfix`), bypassing issue label detection
- `--branch-description`: Force branch description slug instead of deriving from issue title
- `--branch-name`: Use exactly this branch name (skip all generation)
- `--dry-run`: Print what would happen without creating the branch
- `--output json`: Machine-readable output `{"branch":"<name>"}`

### `create-pr` new flags
- All `create-branch` flags above plus:
- `--pr-title`: Override auto-generated PR title
- `--pr-body`: Override auto-generated PR body
- `--pr-body-file`: Read PR body from a file
- `--no-use-existing-branch`: Fail if branch already exists (default non-interactive now **reuses** the existing branch)
- `--label`: Additional label(s) to apply (repeatable)
- `--reviewer`: Request reviewer(s) (repeatable)
- `--assignee`: Assign user(s) (repeatable)
- `--output json`: Machine-readable output `{"branch":"<name>","pr_url":"<url>","draft":<bool>}`

### Behavioral change
In non-interactive mode (`-y`), when a branch already exists for the issue, the old behavior was to **error**. The new default is to **reuse** the existing branch (matching what a human would answer when prompted). The old behavior is available via `--no-use-existing-branch`.

### Documentation
- `docs/USAGE.md`: All new flags documented with examples
- `README.md`: New "AI-assisted development" section with common agent workflows

## Example: fully scripted PR

```sh
gh sherpa create-pr --issue 42 --yes \
  --branch-type feature \
  --branch-description "add-auth" \
  --pr-title "feat: add OAuth endpoint" \
  --pr-body "Closes #42" \
  --reviewer alice \
  --assignee bob \
  --label "priority/high" \
  --no-draft
```

Closes #156