### PR TITLE
fix: sign off the initial empty commit created by Sherpa (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [#160](https://github.com/InditexTech/gh-sherpa/issues/160) The initial empty commit created by Sherpa now includes a `Signed-off-by` trailer (`-s`), so it passes DCO `Check Signed-Off-By` rules
+
 ## [1.6.0] - 2026-05-28
 
 ### Added

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -173,7 +173,9 @@ func (p *Provider) RemoteBranchExists(branch string) (exists bool) {
 func (p *Provider) CommitEmpty(message string) (err error) {
 	signing := CommitSigningEnabled()
 
-	args := []string{"commit", "--allow-empty", "-m", message}
+	// Include -s (--signoff) so the commit carries a Signed-off-by trailer,
+	// required by repositories that enforce the DCO "Check Signed-Off-By" rule.
+	args := []string{"commit", "--allow-empty", "-s", "-m", message}
 
 	if signing {
 		args = append(args, "-S")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -171,6 +171,58 @@ func TestGitBranchExists(t *testing.T) {
 	})
 }
 
+func TestGitCommitEmpty(t *testing.T) {
+	provider := Provider{}
+
+	t.Run("CommitEmpty should include a Signed-off-by trailer when signing is disabled", func(t *testing.T) {
+		var argsSent []string
+		runGitCommand = func(args ...string) (out string, err error) {
+			// Mock git config --get commit.gpgsign to return disabled
+			if len(args) >= 3 && args[0] == "config" && args[1] == "--get" && args[2] == "commit.gpgsign" {
+				return "false\n", nil
+			}
+			argsSent = args
+			return "", nil
+		}
+
+		err := provider.CommitEmpty("chore: initial commit")
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"commit", "--allow-empty", "-s", "-m", "chore: initial commit"}, argsSent)
+	})
+
+	t.Run("CommitEmpty should include both Signed-off-by and GPG signing when signing is enabled", func(t *testing.T) {
+		var argsSent []string
+		runGitCommand = func(args ...string) (out string, err error) {
+			// Mock git config --get commit.gpgsign to return enabled
+			if len(args) >= 3 && args[0] == "config" && args[1] == "--get" && args[2] == "commit.gpgsign" {
+				return "true\n", nil
+			}
+			argsSent = args
+			return "", nil
+		}
+
+		err := provider.CommitEmpty("chore: initial commit")
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"commit", "--allow-empty", "-s", "-m", "chore: initial commit", "-S"}, argsSent)
+	})
+
+	t.Run("CommitEmpty should return an error if the commit fails", func(t *testing.T) {
+		runGitCommand = func(args ...string) (out string, err error) {
+			if len(args) >= 3 && args[0] == "config" && args[1] == "--get" && args[2] == "commit.gpgsign" {
+				return "false\n", nil
+			}
+			err = fmt.Errorf("Failed to run Git command (%w)\n\nDetails:\n%s", err, "foo")
+			return
+		}
+
+		err := provider.CommitEmpty("chore: initial commit")
+
+		assert.Error(t, err)
+	})
+}
+
 func TestGitPushBranch(t *testing.T) {
 	provider := Provider{}
 	t.Run("GitPush should push the branch to origin", func(t *testing.T) {


### PR DESCRIPTION
## What

The initial empty commit generated by Sherpa (`chore: initial commit`) now includes a `Signed-off-by` trailer via `-s`.

## Why

On repositories that enforce the DCO **Check Signed-Off-By** rule, the unsigned initial commit made pushes fail:

```
remote: - Required workflow 'Check Signed-Off-By, Check Signed-Off-By' is not satisfied
```

Only the Sherpa-generated initial commit lacked the trailer; user commits already had it.

## Changes

- `internal/git/git.go` — `CommitEmpty()` now builds `git commit --allow-empty -s -m <msg>` (keeps the existing `-S` GPG signing when `commit.gpgsign` is enabled). Note: `-s` (Signed-off-by / DCO) and `-S` (GPG) are distinct.
- `internal/git/git_test.go` — new `TestGitCommitEmpty` covering: signoff when signing disabled, signoff + GPG when enabled, and the error path.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Testing

Developed with TDD (red → green). Full suite green: `go build ./...` and `go test ./...` pass with no regressions.

Closes #160